### PR TITLE
Switched event ids to uuid7 so that they are time-ordered

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "pyjwt",
     "python-dotenv",
     "typer",
+    "uuid7",
     "uvicorn",
 ]
 

--- a/src/archon/events.py
+++ b/src/archon/events.py
@@ -4,9 +4,14 @@ import pydantic
 import typing
 from pydantic import dataclasses
 
+try:
+    from uuid import uuid7
+except ImportError:
+    from uuid7 import uuid7
+
 
 def uuid_str() -> str:
-    return str(uuid.uuid4())
+    return str(uuid7())
 
 
 class EventType(enum.StrEnum):


### PR DESCRIPTION
I made the import retrocompatible for Python versions before 3.12.
Making Event ids time-ordered make them easier to work with (for instance, in the TWDA)